### PR TITLE
Enable Windows ARM64 builds

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '14'
+- '15'
 c_stdlib:
 - sysroot
 c_stdlib_version:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '14'
+- '15'
 c_stdlib:
 - sysroot
 c_stdlib_version:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '14'
+- '15'
 c_stdlib:
 - sysroot
 c_stdlib_version:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '19'
+- '21'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '19'
+- '21'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:

--- a/.ci_support/win_arm64_.yaml
+++ b/.ci_support/win_arm64_.yaml
@@ -1,0 +1,10 @@
+c_compiler:
+- vs2022
+c_stdlib:
+- vs
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+target_platform:
+- win-arm64

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -82,6 +82,18 @@ jobs:
             resize_partitions: False
             runs_on: ['windows-2022']
             tools_install_dir: D:\Miniforge
+          - CONFIG: win_arm64_
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            build_platform: win-arm64
+            build_workspace_dir: C:\\bld\\
+            docker_run_args: 
+            free_disk_space: skip
+            os: windows
+            pagefile_size: 0
+            resize_partitions: False
+            runs_on: ['windows-11-arm']
+            tools_install_dir: C:\Miniforge
     steps:
 
     - name: Checkout code

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -14,4 +14,5 @@ github:
 provider:
   linux_aarch64: default
   osx_arm64: default
+  win_arm64: default
 test: native_and_emulated

--- a/pixi.toml
+++ b/pixi.toml
@@ -9,7 +9,7 @@ version = "2026.8.9"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/oniguruma-feedstock"
 authors = ["@conda-forge/oniguruma"]
 channels = ["conda-forge"]
-platforms = ["linux-64", "linux-aarch64", "osx-64", "osx-arm64", "win-64"]
+platforms = ["linux-64", "linux-aarch64", "osx-64", "osx-arm64", "win-64", "win-arm64"]
 requires-pixi = ">=0.59.0"
 
 [tasks.build-locally]
@@ -100,6 +100,15 @@ description = "Build oniguruma-feedstock with variant win_64_ directly (without 
 [feature.build.tasks."inspect-win_64_"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_.yaml"
 description = "List contents of oniguruma-feedstock packages built for variant win_64_"
+[feature.build.tasks."build-win_arm64_"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/win_arm64_.yaml"
+description = "Build oniguruma-feedstock with variant win_arm64_ directly (without setup scripts)"
+[feature.build.tasks."debug-win_arm64_"]
+cmd = "rattler-build debug setup --recipe recipe -m .ci_support/win_arm64_.yaml"
+description = "Build oniguruma-feedstock with variant win_arm64_ directly (without setup scripts)"
+[feature.build.tasks."inspect-win_arm64_"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_arm64_.yaml"
+description = "List contents of oniguruma-feedstock packages built for variant win_arm64_"
 
 [environments]
 build = ["build"]

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -12,7 +12,7 @@ source:
   sha256: 2a5cfc5ae259e4e97f86b68dfffc152cdaffe94e2060b770cb827238d769fc05
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
@@ -22,10 +22,8 @@ requirements:
     - ${{ stdlib("c") }}
     - if: win
       then: cmake
-    - make
-  host:
-    - if: win
-      then: msinttypes
+    - if: unix
+      then: make
   run_exports:
     - ${{ pin_subpackage('oniguruma', upper_bound='x.x') }}
 
@@ -42,9 +40,22 @@ tests:
           then:
             - lib/libonig.a
             - lib/pkgconfig/oniguruma.pc
-  - script:
+  - files:
+      recipe:
+        - run_test.c
+    requirements:
+      run:
+        - if: win and arm64
+          then: ${{ compiler("c") }}
+    script:
       - if: unix
         then: onig-config --version
+      - if: win and arm64
+        then:
+          - call %CC% /nologo /I"%LIBRARY_INC%" run_test.c /link /LIBPATH:"%LIBRARY_LIB%" onig.lib /OUT:oniguruma_test.exe
+          - oniguruma_test.exe
+          - dumpbin /headers "%LIBRARY_BIN%\onig.dll" | findstr /I /C:"AA64 machine (ARM64)"
+          - dumpbin /headers oniguruma_test.exe | findstr /I /C:"AA64 machine (ARM64)"
 
 about:
   license: BSD-2-Clause

--- a/recipe/run_test.c
+++ b/recipe/run_test.c
@@ -1,0 +1,60 @@
+#include <stdio.h>
+#include <string.h>
+
+#include <oniguruma.h>
+
+int main(void) {
+  static const UChar pattern[] = "jq";
+  static const UChar text[] = "native jq";
+  OnigEncoding encodings[] = {ONIG_ENCODING_UTF8};
+  OnigErrorInfo error_info;
+  OnigRegion* region;
+  OnigRegex regex;
+  int result;
+
+  result = onig_initialize(encodings, 1);
+  if (result != ONIG_NORMAL) {
+    return 1;
+  }
+
+  result = onig_new(&regex,
+                    pattern,
+                    pattern + strlen((const char*)pattern),
+                    ONIG_OPTION_DEFAULT,
+                    ONIG_ENCODING_UTF8,
+                    ONIG_SYNTAX_DEFAULT,
+                    &error_info);
+  if (result != ONIG_NORMAL) {
+    onig_end();
+    return 1;
+  }
+
+  region = onig_region_new();
+  if (region == NULL) {
+    onig_free(regex);
+    onig_end();
+    return 1;
+  }
+
+  result = onig_search(regex,
+                       text,
+                       text + strlen((const char*)text),
+                       text,
+                       text + strlen((const char*)text),
+                       region,
+                       ONIG_OPTION_NONE);
+
+  if (result != 7 || region->num_regs < 1 || region->beg[0] != 7 ||
+      region->end[0] != 9) {
+    onig_region_free(region, 1);
+    onig_free(regex);
+    onig_end();
+    return 1;
+  }
+
+  onig_region_free(region, 1);
+  onig_free(regex);
+  onig_end();
+  puts("Oniguruma native API smoke test passed.");
+  return 0;
+}


### PR DESCRIPTION
Adds a native Windows ARM64 CMake/NMake build and removes the unused Windows make dependency plus the obsolete msinttypes host dependency.

The installed C consumer exercises a real regex and verifies AA64 for itself and the packaged DLL.